### PR TITLE
Imager.razor.cs: set a MAX_IMAGE_SIZE variable

### DIFF
--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -28,6 +28,8 @@ namespace SDXImageWeb.Pages
 
         private MudTable<SDXFile>? mudTable;
 
+        private int MAX_IMAGE_SIZE = (1024 * 1024) + 16;
+
         public int PercentUsed
         {
             get
@@ -75,7 +77,7 @@ namespace SDXImageWeb.Pages
         private async Task OnRomUploaded(IBrowserFile file)
         {
 
-            if (file.Size > 1024 * 1024)
+            if (file.Size > MAX_IMAGE_SIZE)
             {
                 //message = "The chosen file is not a too large";
                 //messageType = MessageBarType.Error;
@@ -90,7 +92,7 @@ namespace SDXImageWeb.Pages
 
             fileName = file.Name;
 
-            await file.OpenReadStream(1024 * 1024).ReadAsync(fileData);
+            await file.OpenReadStream(MAX_IMAGE_SIZE).ReadAsync(fileData);
             await Task.Delay(1);
 
             //message = null;


### PR DESCRIPTION
- Use a private variable for `MAX_IMAGE_SIZE` instead of hardcoding the max image size
- `MAX_IMAGE_SIZE` is set to the largest cartridge image that I know about, (Maxflash 8mb cart type 42, part of the "Altirra" SDX ROM package), plus the 16 byte cartridge .CAR file header
- Without the extra 16 byte .CAR header, the web UI returns "The file is too large (> 1024kB)" when uploading the SDX Maxflash 8mb CAR image
- Tested changes by uploading the SDX 4.50 Maxflash 8mb CAR image, editing `CONFIG.SYS`, then booting the modified cartridge in Altirra and verifying the edits to `CONFIG.SYS` were in place