### PR TITLE
Add buttons for dumping cartridge/ROM image filelists in JSON, CSV and Plain Text formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ bld/
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 
+# VSCode
+.vscode/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/Pages/Editor.razor
+++ b/Pages/Editor.razor
@@ -1,7 +1,7 @@
 ﻿<MudDialog>
     <DialogContent>
         <div class="d-flex flex-column py-1">
-            <MudTextField T="string" Label="@Title" Variant="Variant.Text" @bind-Value="@ContentText" Lines="5" />
+            <MudTextField T="string" Label="@Title" Variant="Variant.Text" @bind-Value="@ContentText" Lines="10" />
         </div>
     </DialogContent>
     <DialogActions>

--- a/Pages/Imager.razor
+++ b/Pages/Imager.razor
@@ -128,6 +128,16 @@ else if (Loading)
     }
      </MudToolBar>
 
+    <MudExpansionPanels>
+        <MudExpansionPanel Text="Download image file lists" MaxHeight="450" Gutters="true">
+            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">Plain Text</MudButton>
+            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="OnFileListJSON">JSON</MudButton>
+            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">YAML</MudButton>
+            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">CSV</MudButton>
+            <MudText>Click an button to download the file list for this image.  JSON, YAML and CSV formats include file checksums.</MudText>
+        </MudExpansionPanel>
+    </MudExpansionPanels>
+    <br />
     <MudTable Items="sdxRom.Files" Hover="true" SortLabel="Sort By" Elevation="0" RowsPerPage="100" Dense="true" MultiSelection="true"
           @bind-SelectedItems="selectedItems" Filter="new Func<SDXFile,bool>(FilterName)" @ref="mudTable">
         <ToolBarContent>

--- a/Pages/Imager.razor
+++ b/Pages/Imager.razor
@@ -130,7 +130,7 @@ else if (Loading)
 
     <MudExpansionPanels>
         <MudExpansionPanel Text="Download image file lists" MaxHeight="450" Gutters="true">
-            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">Plain Text</MudButton>
+            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="OnFileListPlainText">Plain Text</MudButton>
             <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="OnFileListJSON">JSON</MudButton>
             <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="OnFileListCSV">CSV</MudButton>
             <MudText>Click an button to download the file list for this image.  "Plain Text" includes filenames only, JSON and CSV formats include file sizes and checksums.</MudText>

--- a/Pages/Imager.razor
+++ b/Pages/Imager.razor
@@ -132,7 +132,6 @@ else if (Loading)
         <MudExpansionPanel Text="Download image file lists" MaxHeight="450" Gutters="true">
             <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">Plain Text</MudButton>
             <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="OnFileListJSON">JSON</MudButton>
-            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">YAML</MudButton>
             <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">CSV</MudButton>
             <MudText>Click an button to download the file list for this image.  JSON, YAML and CSV formats include file checksums.</MudText>
         </MudExpansionPanel>

--- a/Pages/Imager.razor
+++ b/Pages/Imager.razor
@@ -132,8 +132,8 @@ else if (Loading)
         <MudExpansionPanel Text="Download image file lists" MaxHeight="450" Gutters="true">
             <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">Plain Text</MudButton>
             <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="OnFileListJSON">JSON</MudButton>
-            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="CloseImage">CSV</MudButton>
-            <MudText>Click an button to download the file list for this image.  JSON, YAML and CSV formats include file checksums.</MudText>
+            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Outlined.TextSnippet" Color="Color.Info" @onclick="OnFileListCSV">CSV</MudButton>
+            <MudText>Click an button to download the file list for this image.  "Plain Text" includes filenames only, JSON and CSV formats include file sizes and checksums.</MudText>
         </MudExpansionPanel>
     </MudExpansionPanels>
     <br />

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -9,7 +9,6 @@ using System;
 using System.Text.Json;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Collections.Specialized;
 
 namespace SDXImageWeb.Pages
 {
@@ -307,7 +306,7 @@ namespace SDXImageWeb.Pages
             await JsModule.InvokeVoidAsync("downloadFileFromStream", fileName, streamRef);
         }
 
-        private string GetSHA1String(byte[] fileByteArray)
+        private static string GetSHA1String(byte[] fileByteArray)
         {
             // using SHA1 instead of MD5
             // https://learn.microsoft.com/en-us/dotnet/core/compatibility/cryptography/5.0/cryptography-apis-not-supported-on-blazor-webassembly
@@ -374,7 +373,7 @@ namespace SDXImageWeb.Pages
                 new JsonSerializerOptions
                 {
                     WriteIndented = true,
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                    PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
                 });
             DownloadFileList(json, "json");
         }

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -299,7 +299,7 @@ namespace SDXImageWeb.Pages
             byte[] bytes = Encoding.UTF8.GetBytes(filelist);
             var memoryStream = new MemoryStream(bytes);
             DateTime now = DateTime.Now;
-            String timestamp = now.ToString("s");
+            string timestamp = now.ToString("s");
             
             var fileName = $"filelist.{timestamp}.{fileExtension}";
             using var streamRef = new DotNetStreamReference(stream: memoryStream);
@@ -308,6 +308,31 @@ namespace SDXImageWeb.Pages
 
         [GeneratedRegex(@"\s+")]
         private static partial Regex FilenameRegex();
+
+        private async void OnFileListCSV()
+        {
+            StringBuilder sb = new();
+            sb.AppendLine("filename,size_in_bytes,sha1_checksum");
+
+            foreach (SDXFile currentFile in sdxRom.Files)
+            {
+                byte[] fileContents = sdxRom.GetFileContents(currentFile);
+                // using SHA1 instead of MD5
+                // https://learn.microsoft.com/en-us/dotnet/core/compatibility/cryptography/5.0/cryptography-apis-not-supported-on-blazor-webassembly
+                byte[] sha1sum = System.Security.Cryptography.SHA1.HashData(fileContents);
+                string sanitizedName = FilenameRegex().Replace(currentFile.Name, ".");
+                sb.Append(sanitizedName)
+                    .Append(',')
+                    .Append(currentFile.Size.ToString())
+                    .Append(',')
+                    .AppendLine(BitConverter.ToString(sha1sum)
+                        .Replace("-", "")
+                        .ToLower()
+                    );
+            }
+
+            DownloadFileList(sb.ToString(), "csv");
+        }
 
         private async void OnFileListJSON()
         {

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -373,6 +373,19 @@ namespace SDXImageWeb.Pages
             DownloadFileList(json, "json");
         }
 
+        private async void OnFileListPlainText()
+        {
+            StringBuilder sb = new();
+
+            foreach(KeyValuePair<string, DumpSDXFile> pair in GetDumpSDXFileSortedDictionary())
+            {
+                DumpSDXFile file = pair.Value;
+                sb.AppendLine(file.Name);
+            }
+
+            DownloadFileList(sb.ToString(), "txt");
+        }
+
     }
 
     public class DumpSDXFile

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -9,6 +9,7 @@ using System;
 using System.Text.Json;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Collections.Specialized;
 
 namespace SDXImageWeb.Pages
 {
@@ -306,29 +307,45 @@ namespace SDXImageWeb.Pages
             await JsModule.InvokeVoidAsync("downloadFileFromStream", fileName, streamRef);
         }
 
+        private string GetSHA1String(byte[] fileByteArray)
+        {
+            // using SHA1 instead of MD5
+            // https://learn.microsoft.com/en-us/dotnet/core/compatibility/cryptography/5.0/cryptography-apis-not-supported-on-blazor-webassembly
+            byte[] sha1ByteArray = System.Security.Cryptography.SHA1.HashData(fileByteArray);
+
+            return BitConverter.ToString(sha1ByteArray)
+                        .Replace("-", "")
+                        .ToLower();
+        }
+
         [GeneratedRegex(@"\s+")]
         private static partial Regex FilenameRegex();
 
         private async void OnFileListCSV()
         {
-            StringBuilder sb = new();
-            sb.AppendLine("filename,size_in_bytes,sha1_checksum");
+            var filesDict = new SortedDictionary<string, DumpSDXFile>();
 
             foreach (SDXFile currentFile in sdxRom.Files)
             {
-                byte[] fileContents = sdxRom.GetFileContents(currentFile);
-                // using SHA1 instead of MD5
-                // https://learn.microsoft.com/en-us/dotnet/core/compatibility/cryptography/5.0/cryptography-apis-not-supported-on-blazor-webassembly
-                byte[] sha1sum = System.Security.Cryptography.SHA1.HashData(fileContents);
-                string sanitizedName = FilenameRegex().Replace(currentFile.Name, ".");
-                sb.Append(sanitizedName)
-                    .Append(',')
-                    .Append(currentFile.Size.ToString())
-                    .Append(',')
-                    .AppendLine(BitConverter.ToString(sha1sum)
-                        .Replace("-", "")
-                        .ToLower()
-                    );
+                byte[] fileByteArray = sdxRom.GetFileContents(currentFile);
+                string sanitizedFileName = FilenameRegex().Replace(currentFile.Name, ".");
+                DumpSDXFile dumpFile = new()
+                {
+                    Name = sanitizedFileName,
+                    Size = currentFile.Size.ToString(),
+                    SHA1 = GetSHA1String(fileByteArray)
+                };
+
+                filesDict.Add(sanitizedFileName, dumpFile);
+            }
+
+            StringBuilder sb = new();
+            sb.AppendLine("filename,size_in_bytes,sha1_checksum");
+
+            foreach(KeyValuePair<string, DumpSDXFile> pair in filesDict)
+            {
+                DumpSDXFile file = pair.Value;
+                sb.AppendLine($"{file.Name},{file.Size},{file.SHA1}");
             }
 
             DownloadFileList(sb.ToString(), "csv");
@@ -341,12 +358,12 @@ namespace SDXImageWeb.Pages
             {
                 String sanitizedName = FilenameRegex().Replace(currentFile.Name, ".");
 
-                DumpSDXFile sdxFile = new()
+                DumpSDXFile dumpFile = new()
                 {
                     Name = sanitizedName, 
                     Size = currentFile.Size.ToString()
                 };
-                outputList.Add(sdxFile);
+                outputList.Add(dumpFile);
             }
 
             var json = JsonSerializer.Serialize(
@@ -365,5 +382,6 @@ namespace SDXImageWeb.Pages
     {
         public string Name { get; set;} = string.Empty;
         public string Size { get; set; } = string.Empty;
+        public string? SHA1 { get; set; }
     }
 }

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -302,7 +302,7 @@ namespace SDXImageWeb.Pages
             DateTime now = DateTime.Now;
             string timestamp = now.ToString("s");
             
-            var fileName = $"filelist.{timestamp}.{fileExtension}";
+            var fileName = $"sdx_img_filelist.{timestamp}.{fileExtension}";
             using var streamRef = new DotNetStreamReference(stream: memoryStream);
             await JsModule.InvokeVoidAsync("downloadFileFromStream", fileName, streamRef);
         }

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -6,6 +6,9 @@ using Microsoft.JSInterop;
 using MudBlazor;
 using System.Reflection.Metadata;
 using System;
+using System.Text.Json;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace SDXImageWeb.Pages
 {
@@ -291,5 +294,58 @@ namespace SDXImageWeb.Pages
             return false;
         }
 
+        private async void DownloadFileList(string filelist, string fileExtension)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(filelist);
+            var memoryStream = new MemoryStream(bytes);
+            DateTime now = DateTime.Now;
+            String timestamp = now.ToString("s");
+            
+            var fileName = $"filelist.{timestamp}.{fileExtension}";
+            using var streamRef = new DotNetStreamReference(stream: memoryStream);
+            await JsModule.InvokeVoidAsync("downloadFileFromStream", fileName, streamRef);
+        }
+
+        [GeneratedRegex(@"\s+")]
+        private static partial Regex FilenameRegex();
+
+        private async void OnFileListJSON()
+        {
+            List<DumpSDXFile> outputList = [];
+            foreach (SDXFile currentFile in sdxRom.Files)
+            {
+                String sanitizedName = FilenameRegex().Replace(currentFile.Name, ".");
+
+                DumpSDXFile sdxFile = new()
+                {
+                    Name = sanitizedName, 
+                    Size = currentFile.Size.ToString()
+                };
+                outputList.Add(sdxFile);
+            }
+
+            var json = JsonSerializer.Serialize(
+                outputList,
+                new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                });
+            DownloadFileList(json, "json");
+            // byte[] bytes = Encoding.UTF8.GetBytes(json);
+            // var memoryStream = new MemoryStream(bytes);
+            // DateTime now = DateTime.Now;
+            // String timestamp = now.ToString("s");
+            
+            // var fileName = $"filelist.{timestamp}.json";
+            // using var streamRef = new DotNetStreamReference(stream: memoryStream);
+            // await JsModule.InvokeVoidAsync("downloadFileFromStream", fileName, streamRef);
+        }
+
+    }
+
+    public class DumpSDXFile
+    {
+        public string Name { get; set;} = string.Empty;
+        public string Size { get; set; } = string.Empty;
     }
 }

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -9,6 +9,7 @@ using System;
 using System.Text.Json;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Collections;
 
 namespace SDXImageWeb.Pages
 {
@@ -317,12 +318,9 @@ namespace SDXImageWeb.Pages
                         .ToLower();
         }
 
-        [GeneratedRegex(@"\s+")]
-        private static partial Regex FilenameRegex();
-
-        private async void OnFileListCSV()
+        private SortedDictionary<string, DumpSDXFile> GetDumpSDXFileSortedDictionary()
         {
-            var filesDict = new SortedDictionary<string, DumpSDXFile>();
+            var dumpFilesDict = new SortedDictionary<string, DumpSDXFile>();
 
             foreach (SDXFile currentFile in sdxRom.Files)
             {
@@ -335,13 +333,20 @@ namespace SDXImageWeb.Pages
                     SHA1 = GetSHA1String(fileByteArray)
                 };
 
-                filesDict.Add(sanitizedFileName, dumpFile);
+                dumpFilesDict.Add(sanitizedFileName, dumpFile);
             }
+            return dumpFilesDict;
+        }
 
+        [GeneratedRegex(@"\s+")]
+        private static partial Regex FilenameRegex();
+
+        private async void OnFileListCSV()
+        {
             StringBuilder sb = new();
             sb.AppendLine("filename,size_in_bytes,sha1_checksum");
 
-            foreach(KeyValuePair<string, DumpSDXFile> pair in filesDict)
+            foreach(KeyValuePair<string, DumpSDXFile> pair in GetDumpSDXFileSortedDictionary())
             {
                 DumpSDXFile file = pair.Value;
                 sb.AppendLine($"{file.Name},{file.Size},{file.SHA1}");
@@ -352,24 +357,14 @@ namespace SDXImageWeb.Pages
 
         private async void OnFileListJSON()
         {
-            List<DumpSDXFile> outputList = [];
-
-            foreach (SDXFile currentFile in sdxRom.Files)
+            List<DumpSDXFile> sortedDumpList = [];
+            foreach(KeyValuePair<string, DumpSDXFile> pair in GetDumpSDXFileSortedDictionary())
             {
-                byte[] fileByteArray = sdxRom.GetFileContents(currentFile);
-                string sanitizedFileName = FilenameRegex().Replace(currentFile.Name, ".");
-                DumpSDXFile dumpFile = new()
-                {
-                    Name = sanitizedFileName,
-                    Size = currentFile.Size.ToString(),
-                    SHA1 = GetSHA1String(fileByteArray)
-                };
-
-                outputList.Add(dumpFile);
+                sortedDumpList.Add(pair.Value);
             }
 
             var json = JsonSerializer.Serialize(
-                outputList,
+                sortedDumpList,
                 new JsonSerializerOptions
                 {
                     WriteIndented = true,

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -328,7 +328,8 @@ namespace SDXImageWeb.Pages
                 outputList,
                 new JsonSerializerOptions
                 {
-                    WriteIndented = true
+                    WriteIndented = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
                 });
             DownloadFileList(json, "json");
         }

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -354,15 +354,18 @@ namespace SDXImageWeb.Pages
         private async void OnFileListJSON()
         {
             List<DumpSDXFile> outputList = [];
+
             foreach (SDXFile currentFile in sdxRom.Files)
             {
-                String sanitizedName = FilenameRegex().Replace(currentFile.Name, ".");
-
+                byte[] fileByteArray = sdxRom.GetFileContents(currentFile);
+                string sanitizedFileName = FilenameRegex().Replace(currentFile.Name, ".");
                 DumpSDXFile dumpFile = new()
                 {
-                    Name = sanitizedName, 
-                    Size = currentFile.Size.ToString()
+                    Name = sanitizedFileName,
+                    Size = currentFile.Size.ToString(),
+                    SHA1 = GetSHA1String(fileByteArray)
                 };
+
                 outputList.Add(dumpFile);
             }
 
@@ -382,6 +385,6 @@ namespace SDXImageWeb.Pages
     {
         public string Name { get; set;} = string.Empty;
         public string Size { get; set; } = string.Empty;
-        public string? SHA1 { get; set; }
+        public string SHA1 { get; set; } = string.Empty;
     }
 }

--- a/Pages/Imager.razor.cs
+++ b/Pages/Imager.razor.cs
@@ -331,14 +331,6 @@ namespace SDXImageWeb.Pages
                     WriteIndented = true
                 });
             DownloadFileList(json, "json");
-            // byte[] bytes = Encoding.UTF8.GetBytes(json);
-            // var memoryStream = new MemoryStream(bytes);
-            // DateTime now = DateTime.Now;
-            // String timestamp = now.ToString("s");
-            
-            // var fileName = $"filelist.{timestamp}.json";
-            // using var streamRef = new DotNetStreamReference(stream: memoryStream);
-            // await JsModule.InvokeVoidAsync("downloadFileFromStream", fileName, streamRef);
         }
 
     }


### PR DESCRIPTION
Hi,

I have added buttons to the UI for downloading the list of files on the currently loaded ROM/CAR image.  

I have wanted something like this for a while, so I can check file sizes/versions "offline", and catalog what files are on which customized images.

You can download the filelist in CSV or JSON formats (includes filename, file size, file SHA1 checksum), or just a list of files in "plain text" format (MS-DOS line endings).  The downloader reuses the existing code in `savefile.js` via a helper method in `Imager.razor.cs`.

For the file checksum, I wanted to use MD5, but that hashing algorithm is no longer supported in Blazor WebAssembly, so SHA1 was the next best option; I wanted a hashing algorithm that most people might have on their machines somewhere.

The buttons are in a `MudExpansionPanels` block in the `Imager.razor` page, in between the Add/Delete Files buttons and the actual list of files.

One last small change, I increased the number of lines in the CONFIG.SYS editor from 5 to 10, I think most people who do a lot of customization of CONFIG.SYS in the web interface would appreciate it.

I'm open to changing any of this stuff, just let me know what works.

Expansion panel closed:
<img width="1768" height="986" alt="Screenshot 2026-02-03 at 23 40 36" src="https://github.com/user-attachments/assets/f488df86-9675-486d-86c4-fb90d6668942" />

Expansion panel opened:
<img width="1746" height="900" alt="Screenshot 2026-02-03 at 23 40 49" src="https://github.com/user-attachments/assets/6f9fc3b4-e4ad-4f16-ae93-a7849c8a745c" />


